### PR TITLE
Change gatsby peer dependency to >=2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "prettier": "1.15.0"
   },
   "peerDependencies": {
-    "gatsby": "next"
+    "gatsby": ">=2.0.0"
   }
 }


### PR DESCRIPTION
Hi, thank you for this great plugin!

I had an issue using this lib because of the `gatsby@next` peer dependency:

```
warning Plugin gatsby-remark-social-cards is not compatible with your gatsby version 2.0.59 - It requires gatsby@next
```