### PR TITLE
update plugin to allow cards to be generated with mdx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,18 +121,21 @@ const generateCard = async (
 module.exports = ({ markdownNode }, options) => {
   const post = markdownNode.frontmatter;
 
-  const output = path.join(
-    "./public",
-    markdownNode.fields.slug,
-    "twitter-card.jpg"
-  );
+  
+  if (markdownNode.fields) {
+    const output = path.join(
+      "./public",
+      markdownNode.fields.slug,
+      "twitter-card.jpg"
+    );
 
-  generateCard(post, options)
-    .then(image =>
-      image
-        .writeAsync(output)
-        .then(() => console.log("Generated Twitter Card:", output))
-        .catch(err => console.log("ERROR GENERATING TWITTER CARD", err))
-    )
-    .catch(console.error);
+    generateCard(post, options)
+      .then(image =>
+        image
+          .writeAsync(output)
+          .then(() => console.log("Generated Twitter Card:", output))
+          .catch(err => console.log("ERROR GENERATING TWITTER CARD", err))
+      )
+      .catch(console.error);
+  }
 };


### PR DESCRIPTION
It updates the plugin so that content coming from gatsby-plugin-mdx can benefit from this also without breaking support for gatsby-transfomer-remark. 

For more context on this pull request see the following [issue](https://github.com/gatsbyjs/gatsby/issues/17970) in the gatsby repo